### PR TITLE
Fix Twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Karbox
 3D printed small hitbox
 
-Follow us on Twitter! https://twitter.com/Karbox_
+Follow us on Twitter! [https://twitter.com/Karbox_](https://twitter.com/Karbox_)
 
 # Introduction
 This repository contains the 3D models to create a Karbox: 


### PR DESCRIPTION
The Twitter link was linking to someone else's Twitter acount. Making the hyperlink explicit ensures it will go to the right account.